### PR TITLE
Fix config leaks and add env samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Node
+node_modules/
+.next/
+
+# Python
+__pycache__/
+*.pyc
+
+# Environment files
+.env
+.env.local
+.env.*.local
+!.env.example
+
+# Uploaded photos
+flashlab1/face_match_app/photos/
+
+# Logs
+npm-debug.log*
+

--- a/flashlab1/face_match_app/main.py
+++ b/flashlab1/face_match_app/main.py
@@ -10,16 +10,16 @@ import uuid
 
 app = FastAPI()
 
+allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-UPLOAD_DIR = "photos"
-THRESHOLD = 0.6
+UPLOAD_DIR = os.getenv("UPLOAD_DIR", "photos")
+THRESHOLD = float(os.getenv("FACE_MATCH_THRESHOLD", "0.6"))
 os.makedirs(UPLOAD_DIR, exist_ok=True)
 
 def get_album_path(album_id: str) -> str:

--- a/flashlab1/face_match_app/requirements.txt
+++ b/flashlab1/face_match_app/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+face_recognition
+numpy

--- a/flashlab1/frontend/.env.example
+++ b/flashlab1/frontend/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-supabase-instance.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/flashlab1/frontend/package-lock.json
+++ b/flashlab1/frontend/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4.1.10",
+        "@types/formidable": "^3.4.5",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1398,6 +1399,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/formidable": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-3.4.5.tgz",
+      "integrity": "sha512-s7YPsNVfnsng5L8sKnG/Gbb2tiwwJTY1conOkJzTMRvJAlLFW1nEua+ADsJQu8N1c0oTHx9+d5nqg10WuT9gHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/flashlab1/frontend/package.json
+++ b/flashlab1/frontend/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4.1.10",
+    "@types/formidable": "^3.4.5",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/flashlab1/frontend/src/lib/supabaseClient.ts
+++ b/flashlab1/frontend/src/lib/supabaseClient.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = 'https://dagnhaetkalledubxtwn.supabase.co'
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRhZ25oYWV0a2FsbGVkdWJ4dHduIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk4MjY5OTksImV4cCI6MjA2NTQwMjk5OX0.jmUP9TxVv0A9IkxmTCNNQ3FDQ6XjYo6j8EBKttrXUoM'
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- ignore development artifacts and environment files
- parameterize FastAPI server with environment variables
- load Supabase keys from environment
- track new dev dependency types
- provide requirements and .env example for easier setup

## Testing
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=example NEXT_PUBLIC_API_URL=http://localhost:8000 npm run build`
- `python -m py_compile flashlab1/face_match_app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68573fffe8ac8321965da7ab8f1e4e25