### PR TITLE
Set production API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 cd ../frontend
 NEXT_PUBLIC_SUPABASE_URL=http://example.com \
 NEXT_PUBLIC_SUPABASE_ANON_KEY=example \
-NEXT_PUBLIC_API_URL=http://localhost:8000 \
+NEXT_PUBLIC_API_URL=https://flashlab.pro \
 npm run build
 ```
 

--- a/flashlab1/frontend/.env.example
+++ b/flashlab1/frontend/.env.example
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-supabase-instance.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=https://flashlab.pro

--- a/flashlab1/frontend/src/pages/api/upload.ts
+++ b/flashlab1/frontend/src/pages/api/upload.ts
@@ -6,6 +6,8 @@ import { IncomingForm, File, Files, Fields } from 'formidable'
 import FormData from 'form-data'
 import fetch from 'node-fetch'
 
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+
 export const config = {
   api: {
     bodyParser: false,
@@ -53,7 +55,7 @@ export default async function handler(req: CustomNextApiRequest, res: NextApiRes
       const formData = new FormData()
       formData.append('file', fs.createReadStream(destPath), filename)
 
-      const fastApiUrl = `http://localhost:8000/add_to_db/?album_id=${albumId}`
+      const fastApiUrl = `${API_BASE}/add_to_db/?album_id=${albumId}`
       const faceRes = await fetch(fastApiUrl, {
         method: 'POST',
         body: formData,

--- a/flashlab1/frontend/src/pages/dashboard/album/[id].tsx
+++ b/flashlab1/frontend/src/pages/dashboard/album/[id].tsx
@@ -5,6 +5,8 @@ import { Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import Image from 'next/image'
 
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+
 export default function AlbumPage() {
   const router = useRouter()
   const { id: slug } = router.query
@@ -32,7 +34,7 @@ export default function AlbumPage() {
 
   const fetchPhotos = useCallback(async () => {
     try {
-      const response = await fetch(`http://localhost:8000/photos/${slug}`)
+      const response = await fetch(`${API_BASE}/photos/${slug}`)
       if (!response.ok) throw new Error('Failed to fetch photos')
       const data = await response.json()
       setPhotos(data.photos || [])
@@ -62,7 +64,7 @@ export default function AlbumPage() {
       formData.append('file', file)
       formData.append('album_id', slug as string)
 
-      const uploadRes = await fetch(`http://localhost:8000/add_to_db/?album_id=${slug}`, {
+      const uploadRes = await fetch(`${API_BASE}/add_to_db/?album_id=${slug}`, {
         method: 'POST',
         body: formData,
       })
@@ -138,8 +140,8 @@ export default function AlbumPage() {
           <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3 w-full">
             {photos.map((filename, i) => (
               <div key={i} className="rounded-md overflow-hidden">
-                <Image
-                  src={`http://localhost:8000/photos/${slug}/${filename}`}
+                  <Image
+                    src={`${API_BASE}/photos/${slug}/${filename}`}
                   alt={`Photo ${i}`}
                   width={300}
                   height={300}


### PR DESCRIPTION
## Summary
- set API URL in `.env.example` and README to `https://flashlab.pro`
- use `NEXT_PUBLIC_API_URL` in upload API route and album dashboard page

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68576823a7448321b93992f4e0804834